### PR TITLE
fix: TS example referring to a state as `this.state.*`

### DIFF
--- a/active-rfcs/0000-vuex-5.md
+++ b/active-rfcs/0000-vuex-5.md
@@ -637,14 +637,14 @@ const useCounter = defineStore({
   getters: {
     // May require annotation as same as Vue Component.
     double(): number {
-      return this.state.count * 2
+      return this.count * 2
     }
   },
 
   actions: {
     // May require annotation as same as Vue Component.
     increment(): void {
-      this.state.count++
+      this.count++
     }
   }
 })


### PR DESCRIPTION
Mistake in RFC confirmed by @posva
[discussion](https://github.com/vuejs/rfcs/discussions/270#discussioncomment-517778)
